### PR TITLE
Tooltip improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ ehthumbs.db
 Icon?
 Thumbs.db
 .DS_Store
+.sass-cache
 
 # delivery specifics #
 ###################

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -312,7 +312,7 @@ nav {
         background-position: 0 -20px; }
 
 .tooltip,
-.tooltip i {
+.tooltip:after {
   position: absolute;
   display: block;
   -webkit-transition: opacity 0.5s ease-out;
@@ -335,7 +335,14 @@ nav {
   -webkit-transition: opacity 0.3s ease-out;
   -moz-transition: opacity 0.3s ease-out;
   transition: opacity 0.3s ease-out; }
-  .tooltip i {
+  .tooltip:before {
+    position: absolute;
+    top: -8px;
+    left: 0px;
+    height: 8px;
+    width: 100%;
+    content: ""; }
+  .tooltip:after {
     top: -10px;
     height: 0;
     width: 0;
@@ -348,7 +355,7 @@ li .tooltip {
   left: -1px;
   white-space: nowrap;
   padding: 4px 9px; }
-  li .tooltip i {
+  li .tooltip:after {
     left: 20px; }
 
 .info .tooltip {
@@ -356,7 +363,7 @@ li .tooltip {
   right: 0;
   min-width: 240px;
   padding: 8px 13px; }
-  .info .tooltip i {
+  .info .tooltip:after {
     right: 5px; }
 
 .notice {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -119,8 +119,6 @@ nav {
 		height: 18px;
 	
 		a {
-			
-			
 			text-indent: -9999em;
 			overflow: hidden;
 			
@@ -142,10 +140,9 @@ nav {
 // Tooltip Generic 
 
 .tooltip,
-.tooltip i {
+.tooltip:after {
 	position: absolute;
 	display: block;
-	
 	@include transition("opacity 0.5s ease-out");
 }
 
@@ -174,10 +171,17 @@ nav {
 	
 	@include transition("opacity 0.3s ease-out");
 	
+	&:before{
+		position:absolute;
+		top: -8px;
+		left:0px;
+		height: 8px;
+		width: 100%;
+		content: "";
+	}
 	
 	// Tooltip Arrow
-	
-	i {
+	&:after {
 		top: -10px;
 		
 		height: 0;
@@ -191,29 +195,28 @@ nav {
 	}
 }
 
-	li .tooltip {
-		left: -1px;
-		white-space: nowrap;
+li .tooltip {
+	left: -1px;
+	white-space: nowrap;
+
+	padding: 4px 9px;
 	
-		padding: 4px 9px;
-		
-		i {
-			left: 20px;
-		}
+	&:after {
+		left: 20px;
 	}
+}
+
+.info .tooltip {
+	top: 29px;
+	right: 0;
 	
-	.info .tooltip {
-		top: 29px;
-		right: 0;
-		
-		min-width: 240px;
-	
-		padding: 8px 13px;
-		
-		i {
-			right: 5px;
-		}
+	min-width: 240px;
+
+	padding: 8px 13px;
+	&:after {
+		right: 5px;
 	}
+}
 
 
 .notice {

--- a/index.php
+++ b/index.php
@@ -1,17 +1,15 @@
 <?php
 	// 	Public root path.
 	define("R", str_replace("index.php", "", $_SERVER['PHP_SELF']));
-
 	include("core/init.php");
+?>
 
-?><!DOCTYPE html>
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" class="no-js">
 
 <head>
 	<meta charset="UTF-8" />
-
 	<title>Delivery</title>
-
 	<style>
 		@import "<?=R; ?>assets/css/main.css";
 	</style>
@@ -45,7 +43,7 @@
 					$current_preview = $preview;
 					$preview_class .= 'active ';
 				}
-				?><li class="<?=$preview_class; ?>"><a href="<?=R.$cur_project."_/".$preview['slug']; ?>"><?=$label ?></a><? if($has_tooltip) { ?> <b class="tooltip"><?=htmlentities($label); ?><i></i></b><? } ?></li><?
+				?><li class="<?=$preview_class; ?>"><a href="<?=R.$cur_project."_/".$preview['slug']; ?>"><?=$label ?></a><? if($has_tooltip) { ?> <b class="tooltip"><?=htmlentities($label); ?></b><? } ?></li><?
 			}
 		?>
 		</ul>
@@ -61,8 +59,6 @@
 
 				<div class="tooltip">
 					<?=htmlentities(file_get_contents($info_glob[0])); ?>
-
-					<i></i>
 				</div>
 			</div>
 		<? } ?>


### PR DESCRIPTION
Just a small suggestion to improve tooltip behavior and markup :)

I removed the empty `<i>` element and replaced it with an :after psuedo class.

I also noticed there was some glitchy behavior when you move your mouse from a navigation item to the tooltip (it fades out then back in). So I used :before to provide a bridge element from the trigger to the tooltip.

There is still the issue of tooltips being triggered by hovering over them when they are invisible. I can't think of a pure-css way to fix this unless the fade effect is removed. Maybe keyframe animation can accomplish this? (fade out, then display:none, or position top:-999px)
